### PR TITLE
Bug fixes 2

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -21,9 +21,10 @@
 Project Pythia is a community effort led by NCAR and the University
 at Albany, and funded by NSF EarthCube awards \#2026899 and \#2026863.
 
-```{figure} _static/images/NSF_4-Color_vector_logo.svg
+```{image} _static/images/NSF_4-Color_vector_Logo.svg
 :name: NSF
 :height: 75px
+:align: left
 ```
 ````
 **_A Community Educational Resource for Geoscientists_**


### PR DESCRIPTION
Turns out is wasn't the `image` directive, but a typo with the *case* of one letter in the NSF logo URL.  This fixes that (which doesn't display on my machine, annoyingly).