### PR TITLE
Enable documentation autobuilds on Readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+# Required
+version: 2
+
+sphinx:
+  configuration: content/conf.py
+
+python:
+  version: 3
+  setup_py_install: true
+  system_packages: true
+  install:
+    - requirements: requirements.txt


### PR DESCRIPTION
Towards fixing https://github.com/ProjectPythia/projectpythia.github.io/issues/16 by taking advantage of https://docs.readthedocs.io/en/stable/guides/autobuild-docs-for-pull-requests.html