### PR TITLE
Add link to GitHub Discussions on Portal

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -61,6 +61,7 @@ pages/people.md
 pages/meetings.md
 pages/contributing.md
 pages/code_of_conduct.md
+pages/discussion.md
 pages/links.md
 ```
 
@@ -74,5 +75,5 @@ caption: Galleries
 notebooks_gallery/index.md
 pages/communications.md
 
-``` 
+```
 -->

--- a/content/pages/discussion.md
+++ b/content/pages/discussion.md
@@ -1,0 +1,4 @@
+# Talk to us!
+
+If you have questions or want to share anything with the [Project Pythia Team](people.md),
+please reach out to us on our [GitHub Discussions page](https://github.com/ProjectPythia/projectpythia.github.io/discussions).


### PR DESCRIPTION
This is a draft to add a link to the new GitHub Discussions page on the Portal.  Let me know what you think!