### PR TITLE
Update meeting notes link

### DIFF
--- a/content/pages/meetings.md
+++ b/content/pages/meetings.md
@@ -2,10 +2,9 @@
 
 ## Weekly Working Group Meetings
 
-Project Pythia holds weekly public meetings every Thursday at 11:00AM Mountain (1:00PM Eastern) on Zoom.  Please find links and information about how to join in the calendar below.
-These meetings are open to anyone who wishes to participate.  These meetings alternate focus
-between the two Project Pythia Working Groups on Infrastructure and Education.
-We publish the [Infrastructure Working Group (IWG) meeting notes here](https://docs.google.com/document/d/e/2PACX-1vQN5YFkZtCZPKVk2Rte2xoHuiqJuYz1KpynsSKmeCLwP-4glUsGuCPJbITwB4OJc8dOhUpHAMacdx59/pub) and the [Education Working Group (EWG) meeting notes here](https://docs.google.com/document/d/e/2PACX-1vTHJKdeWfQBbkrGt8RsSVKJHy5uAQumD40_hRXhRKDGpLO-4ACBlMdQNyR-ap-Q19Zwdq2m5yUk_mZk/pub).
+Project Pythia holds weekly public meetings every Thursday at 11:00AM Mountain (1:00PM Eastern) on Zoom. Please find links and information about how to join in the calendar below.
+These meetings are open to anyone who wishes to participate.
+We publish [weekly meeting notes here](https://docs.google.com/document/d/e/2PACX-1vQN5YFkZtCZPKVk2Rte2xoHuiqJuYz1KpynsSKmeCLwP-4glUsGuCPJbITwB4OJc8dOhUpHAMacdx59/pub).
 
 ## Meeting & Event Calendar
 


### PR DESCRIPTION
I have unified the two WG notes documents into 1 Google Doc, and I have updated the Pythia Google Calendar events, too.

Closes #42.