### PR TITLE
Attempt to add Google Analytics to portal

### DIFF
--- a/content/_templates/layout.html
+++ b/content/_templates/layout.html
@@ -1,0 +1,15 @@
+{% extends "!layout.html" %} {% block extrahead %}
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script
+  async
+  src="https://www.googletagmanager.com/gtag/js?id=G-T9KGMX7VHZ"
+></script>
+<script>
+  window.dataLayer = window.dataLayer || []
+  function gtag() {
+    dataLayer.push(arguments)
+  }
+  gtag('js', new Date())
+  gtag('config', 'G-T9KGMX7VHZ')
+</script>
+{{ super() }} {% endblock %}


### PR DESCRIPTION
This adds the necessary javascript to the head section of the Sphinx theme template to enable Google Analytics tracking.