### PR TITLE
Make environment.yml consistent with requirements.txt

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -3,10 +3,8 @@ channels:
   - conda-forge
 dependencies:
   - myst-nb==0.10.1
-  - sphinx-panels
-  - pydata-sphinx-theme
-  - jupyterlab
-  - sphinx-autobuild
-  - matplotlib
   - sphinx-book-theme
+  - sphinx-panels
+  - matplotlib
   - pandas
+  - pyyaml


### PR DESCRIPTION
Fixes #68 

This just makes our `ci/environment.yml` file (used by conda to make the build environment when building the site locally) consistent with `requirements.txt` (used by pip to make the build environment on readthedocs)

It would be better to avoid duplicating the build requirements. I'll open a separate issue about that.