### PR TITLE
Fix deprecated myst config

### DIFF
--- a/content/conf.py
+++ b/content/conf.py
@@ -4,8 +4,8 @@
 import datetime
 import os
 import pathlib
-import sys
 import shutil
+import sys
 from textwrap import dedent
 
 import yaml
@@ -71,8 +71,8 @@ html_theme_options = {
 panels_add_bootstrap_css = False
 
 # MyST config
-myst_admonition_enable = True
-myst_deflist_enable = True
+myst_enable_extensions = ['amsmath', 'colon_fence', 'deflist', 'html_image']
+myst_url_schemes = ('http', 'https', 'mailto')
 jupyter_execute_notebooks = 'off'
 
 # CUSTOM SCRIPTS =============================================================


### PR DESCRIPTION
This PR addresses the warnings  the user would get when building html 

```bash 
WARNING: config `myst_admonition_enable` is deprecated, please add "colon_fence" to `myst_enable_extensions = []` WARNING: config `myst_deflist_enable` is deprecated, please add "deflist" to `myst_enable_extensions = []`
```