### PR TITLE
Disable pre-commit hooks for the time being

### DIFF
--- a/.github/workflows/update-external-links-gallery.yaml
+++ b/.github/workflows/update-external-links-gallery.yaml
@@ -104,9 +104,9 @@ jobs:
               links.append(data)
               yaml.dump(links, f)
 
-      - name: Run pre-commit hooks
-        run: |
-          python -m pre_commit run --all-files
+      # - name: Run pre-commit hooks
+      #   run: |
+      #     python -m pre_commit run --all-files
 
       - name: Create pull request
         id: cpr


### PR DESCRIPTION
This disables `pre-commit` hooks until we have a workflow for running `pre-commit` checks as part of the CI. 

