### PR TITLE
Add pre-commit to environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ cd projectpythia.github.io/content
 Use [conda](https://docs.conda.io/) to set up a build environment:
 
 ```bash
-conda env create -f ../ci/environment.yml
+conda env update -f ../ci/environment.yml
 ```
 
 This will create or update the dev environment (`pythia`).

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -9,3 +9,4 @@ dependencies:
   - matplotlib
   - pandas
   - pyyaml
+  - pre-commit


### PR DESCRIPTION
Closes #122 

- Add `pre-commit` to the `pythia` environment in `ci/environment.yml`
- Update instructions to use `conda env update` rather than `conda env create`