### PR TITLE
Use Pythia Foundations as the book title consistently

### DIFF
--- a/portal/contributing.md
+++ b/portal/contributing.md
@@ -59,7 +59,7 @@ are requested.
 
 ### Add a new Jupyter Notebook to Pythia Foundations
 
-[Project Pythia Foundations](https://foundations.projectpythia.org)
+[Pythia Foundations](https://foundations.projectpythia.org)
 is a collection of material that the Pythia team believes is essential
 knowledge for geoscientists to effectively use the Scientific Python
 Ecosystem. The Pythia Foundations content is hosted on a separate

--- a/portal/foundations.md
+++ b/portal/foundations.md
@@ -1,5 +1,5 @@
-# Project Pythia Foundations
+# Pythia Foundations
 
 We are currently developing a **comprehensive set of tutorials** covering the **foundational skills** everyone needs to get started with **scientific computing in the open-source Python ecosystem**. These foundational tutorials will serve as **common references** for more advanced and domain-specific content to be housed here in the Pythia Portal.
 
-You can find the _under-construction_ Foundations content at <https://foundations.projectpythia.org/>.
+You can find the _under-construction_ Pythia Foundations content at <https://foundations.projectpythia.org/>.

--- a/portal/gallery.yaml
+++ b/portal/gallery.yaml
@@ -1243,7 +1243,7 @@
 - title: Pythia Foundations - Getting started with Python
   url: https://foundations.projectpythia.org/foundations/getting-started-python.html
   description: |
-    This chapter of the Project Pythia Foundations book covers Python spin-up for new users. Here you will look at your first Python code and learn to run/install Python on various platforms.
+    This chapter of the Pythia Foundations book covers Python spin-up for new users. Here you will look at your first Python code and learn to run/install Python on various platforms.
   authors:
     - name: Project Pythia
       email: projectpythia@ucar.edu
@@ -1260,7 +1260,7 @@
 - title: Pythia Foundations - Getting started with Jupyter
   url: https://foundations.projectpythia.org/foundations/getting-started-jupyter.html
   description: |
-    This chapter of the Project Pythia Foundations book covers Python spin-up using Jupyter. Here you will learn about the JupyterLab interface and markdown formatting.
+    This chapter of the Pythia Foundations book covers Python spin-up using Jupyter. Here you will learn about the JupyterLab interface and markdown formatting.
   authors:
     - name: Project Pythia
       email: projectpythia@ucar.edu
@@ -1277,7 +1277,7 @@
 - title: Pythia Foundations - Getting started with GitHub
   url: https://foundations.projectpythia.org/foundations/getting-started-github.html
   description: |
-    This chapter of the Project Pythia Foundations book covers GitHub: what it is, basic version control, and how to open a pull request.
+    This chapter of the Pythia Foundations book covers GitHub: what it is, basic version control, and how to open a pull request.
   authors:
     - name: Project Pythia
       email: projectpythia@ucar.edu
@@ -1294,7 +1294,7 @@
 - title: Pythia Foundations - Numpy
   url: https://foundations.projectpythia.org/core/numpy.html
   description: |
-    This chapter of the Project Pythia Foundations book covers the Python package NumPy: NumPy basics, intermediate NumPy, and NumPy broadcasting.
+    This chapter of the Pythia Foundations book covers the Python package NumPy: NumPy basics, intermediate NumPy, and NumPy broadcasting.
   authors:
     - name: Project Pythia
       email: projectpythia@ucar.edu
@@ -1311,7 +1311,7 @@
 - title: Pythia Foundations - Matplotlib
   url: https://foundations.projectpythia.org/core/matplotlib.html
   description: |
-    This chapter of the Project Pythia Foundations book covers basics of the Python package Matplotlib.
+    This chapter of the Pythia Foundations book covers basics of the Python package Matplotlib.
   authors:
     - name: Project Pythia
       email: projectpythia@ucar.edu
@@ -1330,7 +1330,7 @@
 - title: Pythia Foundations - Cartopy
   url: https://foundations.projectpythia.org/core/cartopy.html
   description: |
-    This chapter of the Project Pythia Foundations book introduces the Python package Cartopy, a package designed for geospatial data processing and used for its ability to produce maps.
+    This chapter of the Pythia Foundations book introduces the Python package Cartopy, a package designed for geospatial data processing and used for its ability to produce maps.
   authors:
     - name: Project Pythia
       email: projectpythia@ucar.edu
@@ -1349,7 +1349,7 @@
 - title: Pythia Foundations - Datetime
   url: https://foundations.projectpythia.org/core/datetime.html
   description: |
-    This section of the Project Pythia Foundations book contains tutorials on dealing with times and calendars in scientific Python, beginning with use of the datetime standard library.
+    This section of the Pythia Foundations book contains tutorials on dealing with times and calendars in scientific Python, beginning with use of the datetime standard library.
   authors:
     - name: Project Pythia
       email: projectpythia@ucar.edu
@@ -1366,7 +1366,7 @@
 - title: Pythia Foundations - Pandas
   url: https://foundations.projectpythia.org/core/pandas.html
   description: |
-    This section of the Project Pythia Foundations book covers Pandas, a very powerful library for working with tabular data (i.e. anything you might put in a spreadsheet – a common data type in the geosciences).
+    This section of the Pythia Foundations book covers Pandas, a very powerful library for working with tabular data (i.e. anything you might put in a spreadsheet – a common data type in the geosciences).
   authors:
     - name: Project Pythia
       email: projectpythia@ucar.edu
@@ -1383,7 +1383,7 @@
 - title: Pythia Foundations - Data Formats
   url: https://foundations.projectpythia.org/core/pandas.html
   description: |
-    This section of the Project Pythia Foundations book covers how to interact in Python with data file formats in widespread use in the geosciences, such as NetCDF.
+    This section of the Pythia Foundations book covers how to interact in Python with data file formats in widespread use in the geosciences, such as NetCDF.
   authors:
     - name: Project Pythia
       email: projectpythia@ucar.edu
@@ -1402,7 +1402,7 @@
 - title: Pythia Foundations - Xarray
   url: https://foundations.projectpythia.org/core/xarray.html
   description: |
-    This section of the Project Pythia Foundations book contains tutorials on using Xarray. Xarray is used widely in the geosciences and beyond for analysis of gridded N-dimensional datasets.
+    This section of the Pythia Foundations book contains tutorials on using Xarray. Xarray is used widely in the geosciences and beyond for analysis of gridded N-dimensional datasets.
   authors:
     - name: Project Pythia
       email: projectpythia@ucar.edu

--- a/portal/index.md
+++ b/portal/index.md
@@ -44,7 +44,7 @@ domain-specific content to be housed here in the Pythia Portal.
 
 <span class="d-flex justify-content-center pt-1 pb-3">
     <a href="https://foundations.projectpythia.org" role="button" class="btn btn-primary btn-lg">
-        Read the Project Pythia Foundations Book
+        Read the Pythia Foundations Book
     </a>
 </span>
 


### PR DESCRIPTION
Addresses https://github.com/ProjectPythia/pythia-foundations/issues/176 by referring to the book consistently as "Pythia Foundations" rather than "Project Pythia Foundations".