### PR TITLE
Fix shortening of Unidata description

### DIFF
--- a/portal/gallery.yaml
+++ b/portal/gallery.yaml
@@ -21,7 +21,7 @@
 - title: Unidata Python Training
   url: https://unidata.github.io/python-training/python/intro-to-python/
   description: |
-    Introduction to Python for Atmospheric Science & Meteorology. Unidata is working to create a collection of online training materials focused on the use of Python in the atmospheric sciences. While our examples and scenarios may feature Unidata tools and data technologies, our aim is to present a generic set of freely available tools that are generally useful to scientists, educators, and students in the geosciences, broadly defined.
+    Introduction to Python for Atmospheric Science and Meteorology. Unidata is working to create a collection of online training materials focused on the use of Python in the atmospheric sciences. While our examples and scenarios may feature Unidata tools and data technologies, our aim is to present a generic set of freely available tools that are generally useful to scientists, educators, and students in the geosciences, broadly defined.
   authors:
   - institution: Unidata
     institution_url: https://www.unidata.ucar.edu/


### PR DESCRIPTION
Unidata Python Training card's description is shortened at the "&" without the ellipsis text added (or the modal-btn). This is a simple fix to change the "&" to "and" to see if that plays better with the `truncate()` function.

Related to #235