### PR TITLE
Make a placeholder Cookbooks landing page and link to it

### DIFF
--- a/portal/cookbooks.md
+++ b/portal/cookbooks.md
@@ -1,0 +1,13 @@
+# Pythia Cookbooks
+
+```{note}
+This content is under construction!
+```
+
+This is a placeholder page for the Pythia Cookbooks initiative.
+
+Cookbooks are collections of tutorials and example workflows on advanced or domain-specific topics.
+
+## Cookbooks currently available / under construction
+
+- [Radar Cookbook](https://projectpythiatutorials.github.io/radar-cookbook/landing-page.html) by Max Grover. See [here](https://github.com/ProjectPythiaTutorials/radar-cookbook) for the source repo.

--- a/portal/index.md
+++ b/portal/index.md
@@ -99,7 +99,7 @@ the example data used by the [Pythia Foundations Book](https://foundations.proje
 Coming soon!!! Pythia Cookbooks are collections of more advanced and domain-specific example workflows building on top of Pythia Foundations.
 
 <span class="d-flex justify-content-center pt-1 pb-3">
-    <a href="https://github.com/ProjectPythia/pythia-cookbook" role="button" class="btn btn-primary btn-lg">
+    <a href="cookbooks.html" role="button" class="btn btn-primary btn-lg">
         Visit Pythia Cookbooks
     </a>
 </span>
@@ -373,5 +373,6 @@ maxdepth: 1
 about.md
 contributing.md
 code_of_conduct.md
+cookbooks.md
 gallery.md
 ```


### PR DESCRIPTION
Related to #240, this PR creates a placeholder landing page for the eventual Cookbooks gallery, puts a link to @mgrover1's Radar Cookbook on the landing page, and links to this landing page from the Cookbooks button on the main landing page.

This PR does not change the top navbar.