### PR TITLE
Remove "Pythia" from gallery titles

### DIFF
--- a/portal/_extensions/cookbook_gallery_generator.py
+++ b/portal/_extensions/cookbook_gallery_generator.py
@@ -7,7 +7,7 @@ def main(app):
     with open('cookbook_gallery.yaml') as fid:
         all_items = yaml.safe_load(fid)
 
-    title = 'Pythia Cookbooks Gallery'
+    title = 'Cookbooks Gallery'
     subtext = 'Pythia Cookbooks provide example workflows on more advanced and domain-specific problems developed by the Pythia community. Cookbooks build on top of skills you learn in Pythia Foundations.'
     menu_html = generate_menu(all_items)
     build_from_items(all_items, 'cookbook-gallery', title=title, subtext=subtext, menu_html=menu_html)

--- a/portal/_extensions/resource_gallery_generator.py
+++ b/portal/_extensions/resource_gallery_generator.py
@@ -7,7 +7,7 @@ def main(app):
     with open('resource_gallery.yaml') as fid:
         all_items = yaml.safe_load(fid)
 
-    title = 'Pythia Resource Gallery'
+    title = 'Resource Gallery'
     submit_btn_link = 'https://github.com/ProjectPythia/projectpythia.github.io/issues/new?assignees=&labels=resource-gallery-submission&template=update-resource-gallery.md&title='
     submit_btn_txt = 'Submit a new resource'
     menu_html = generate_menu(all_items, submit_btn_txt=submit_btn_txt, submit_btn_link=submit_btn_link)


### PR DESCRIPTION
The gallery titles are too long. The "Pythia Cookbooks Gallery" title takes up too lines with the current CSS. The fastest fix is to remove the word "Pythia" from the title. 

Further CSS revisions for different screen sizes in another PR.

See discussion in #256 