### PR TITLE
Provide link to Pangeo Discourse category

### DIFF
--- a/portal/contributing.md
+++ b/portal/contributing.md
@@ -25,7 +25,7 @@ to another community member’s question. There are a number of ways
 to have a dialogue with the Pythia community, such as by opening a
 GitHub issue, but the easiest method is to simply create (or respond
 to) a post on our [discussion
-forum](https://github.com/ProjectPythia/projectpythia.github.io/discussions).
+forum](https://discourse.pangeo.io/c/education/project-pythia/).
 
 ### Add content to the Resource Gallery
 


### PR DESCRIPTION
It took me a minute to find the appropriate place to ask https://discourse.pangeo.io/t/questions-about-pythia-cookbooks/3021/2 based on the conversations in https://github.com/ProjectPythia/projectpythia.github.io/discussions, updating this link based on my interpretation so it will hopefully be quicker for others.
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
