### PR TITLE
Add nightly-build status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project Pythia Portal
 
-![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/NCAR/pythia-portal/deploy-site/main?logo=github&style=for-the-badge)
+[![nightly-build](https://github.com/ProjectPythia/projectpythia.github.io/actions/workflows/nightly-build.yaml/badge.svg)](https://github.com/ProjectPythia/projectpythia.github.io/actions/workflows/nightly-build.yaml)
 
 This is the source repository for the [Project Pythia portal](https://projectpythia.org).
 The portal site is built with [sphinx](https://www.sphinx-doc.org/).


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
With #310 we now have a nightly build for this repo.

This PR adds a status badge for that nightly build, and removes the broken old badge.