### PR TITLE
Remove pinned versions in .pre-commit-config.yaml / update isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,26 +24,13 @@ repos:
     hooks:
       - id: flake8
 
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-      - id: seed-isort-config
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
-
-  # - repo: https://github.com/prettier/pre-commit
-  #   rev: 57f39166b5a5a504d6808b87ab98d41ebf095b46
-  #   hooks:
-  #     - id: prettier
 
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.6.1
     hooks:
       - id: nbqa-black
-        additional_dependencies: [black==20.8b1]
       - id: nbqa-pyupgrade
-        additional_dependencies: [pyupgrade==2.7.3]
-      # - id: nbqa-isort
-      #   additional_dependencies: [isort==5.6.4]


### PR DESCRIPTION
As noted in #307 , pre-commit was failing with an unhelpful message, **_The Poetry configuration is invalid_**. Updating `.pre-commit-config.yaml` so that the latest (5.12.0) version of `isort` is used looks to be the key fix here (see #312), but I also eliminated what seems to be unnecessary pinned versions of `nbqa-black` and `nbqa-pyupgrade` hooks in `nbqa`, and also eliminated the now-deprecated `seed-isort-config` repo.