### PR TITLE
add link to event page from portal

### DIFF
--- a/portal/index.md
+++ b/portal/index.md
@@ -9,7 +9,7 @@
 
 <span style="font-size: 2.6rem;">An education and training hub for the geoscientific Python community</span>
 
-<a href="https://projectpythia.org/pythia-cookoff-2023/README.html" role="button" class="btn btn-light btn-lg" style="display: flex; align-items: center; font-weight: 600; text-decoration: none;">
+<a href="https://projectpythia.org/pythia-cookoff-2023/README.html" role="button" class="btn btn-light btn-lg" style="display: flex; align-items: center; font-weight: 600; text-decoration: none; background-color: #ccc; border: rgba(var(--spt-color-dark), 1);">
         Project Pythia is hosting a Cookbook Cook-Off June 20-23, 2023.<br>
         Learn more here.
 </a>

--- a/portal/index.md
+++ b/portal/index.md
@@ -9,8 +9,10 @@
 
 <span style="font-size: 2.6rem;">An education and training hub for the geoscientific Python community</span>
 
-> 🍪 <span style="color:white"> Project Pythia is hosting a Cookbook Cook-Off June 20-23, 2023 in Boulder, CO and online. Learn more on our [event page](https://projectpythia.org/pythia-cookoff-2023/README.html).
-</span>
+<a href="https://projectpythia.org/pythia-cookoff-2023/README.html" role="button" class="btn btn-light btn-lg" style="display: flex; align-items: center; font-weight: 600; text-decoration: none;">
+        Project Pythia is hosting a Cookbook Cook-Off June 20-23, 2023.<br>
+        Learn more here.
+</a>
 
 [Project Pythia](about) is the education working group for [Pangeo](https://pangeo.io)
 and is an educational resource for the entire geoscience community.

--- a/portal/index.md
+++ b/portal/index.md
@@ -9,6 +9,9 @@
 
 <span style="font-size: 2.6rem;">An education and training hub for the geoscientific Python community</span>
 
+> 🍪 <span style="color:white"> Project Pythia is hosting a Cookbook Cook-Off June 20-23, 2023 in Boulder, CO and online. Learn more on our [event page](https://projectpythia.org/pythia-cookoff-2023/README.html).
+</span>
+
 [Project Pythia](about) is the education working group for [Pangeo](https://pangeo.io)
 and is an educational resource for the entire geoscience community.
 Together these initiatives are helping geoscientists make sense of huge volumes of


### PR DESCRIPTION
This PR adds a link to the event on the main portal page. Perhaps we want to link this differently, but this was the easiest solution I found.

Eventually we may want an "events" tab in the nav bar that lists past events, events we'll be present at or give talks/tutorials, and events that we host.
