### PR TITLE
add dask tag to xarray tutorial

### DIFF
--- a/portal/resource_gallery.yaml
+++ b/portal/resource_gallery.yaml
@@ -761,8 +761,10 @@
   tags:
     packages:
     - xarray
+    - dask
     formats:
     - tutorial
+
 - title: Python Programming for Earth Science Students
   description: Python Programming for Earth Science Students
   url: https://nbviewer.jupyter.org/github/ltauxe/Python-for-Earth-Science-Students/tree/master/


### PR DESCRIPTION
Within the Xarray tutorial is a great Dask notebook https://tutorial.xarray.dev/intermediate/xarray_and_dask.html so I wanted to add the dask package tag to the Xarray tutorial card.