### PR TITLE
Remove hackathon banner

### DIFF
--- a/portal/index.md
+++ b/portal/index.md
@@ -9,11 +9,6 @@
 
 <span style="font-size: 2.6rem;">An education and training hub for the geoscientific Python community</span>
 
-<a href="https://projectpythia.org/pythia-cookoff-2023/README.html" role="button" class="btn btn-light btn-lg" style="display: flex; align-items: center; font-weight: 600; text-decoration: none; background-color: #ccc; border: rgba(var(--spt-color-dark), 1);">
-        Project Pythia is hosting a Cookbook Cook-Off June 20-23, 2023.<br>
-        Learn more here.
-</a>
-
 [Project Pythia](about) is the education working group for [Pangeo](https://pangeo.io)
 and is an educational resource for the entire geoscience community.
 Together these initiatives are helping geoscientists make sense of huge volumes of


### PR DESCRIPTION
Remove Hackathon banner now that event has ended. We can use this space for the post-survey or a SciPy ad if we need, but I'm glad to say goodbye to it for now. Reverts #328.