### PR TITLE
Address #349: Fix broken links to the Pythia team in a few places

### DIFF
--- a/portal/index.md
+++ b/portal/index.md
@@ -149,9 +149,9 @@ the example data used by the [Pythia Foundations Book](https://foundations.proje
 
 ## Join us!
 
-If you have questions or want to share anything with the Project 
-Pythia Team, please reach out to us through the [Project Pythia 
-category on the Pangeo Discourse forum](https://discourse.pangeo.io/c/education/project-pythia/)  
+If you have questions or want to share anything with the Project
+Pythia Team, please reach out to us through the [Project Pythia
+category on the Pangeo Discourse forum](https://discourse.pangeo.io/c/education/project-pythia/)
 below or join us at our [Weekly Working Group Meetings](#weekly-working-group-meetings).
 
 <span class="d-flex justify-content-center pt-1 pb-4">

--- a/portal/index.md
+++ b/portal/index.md
@@ -152,7 +152,7 @@ the example data used by the [Pythia Foundations Book](https://foundations.proje
 If you have questions or want to share anything with the Project
 Pythia Team, please reach out to us through the [Project Pythia
 category on the Pangeo Discourse forum](https://discourse.pangeo.io/c/education/project-pythia/)
-below or join us at our [Weekly Working Group Meetings](#weekly-working-group-meetings).
+or join us at our [Weekly Working Group Meetings](#weekly-working-group-meetings).
 
 <span class="d-flex justify-content-center pt-1 pb-4">
     <a href="https://discourse.pangeo.io/c/education/project-pythia/" role="button" class="btn btn-primary btn-lg">


### PR DESCRIPTION
Closes #349 

The places that were pointed out in the issue 349 (i.e. "The Project Team" in the page footer and in the [Who is Project Pythia section](https://projectpythia.org/about.html#who-is-project-pythia) of the About page) have already been accidentally merged via this [commit](https://github.com/ProjectPythia/projectpythia.github.io/commit/161e6918fc2dbc78aa3f5bd1dab36e02ee42e56a) last week.

This PR additionally fixed a link in the "Join us!" part in index.md. Additional search for the "team" did not return any links to the formerly removed team part in index.md.

So, all changes that need to be done for the team links should be done now.