### PR TITLE
Fix the broken resource gallery submission validation

### DIFF
--- a/.github/workflows/collect-user-submission.py
+++ b/.github/workflows/collect-user-submission.py
@@ -28,16 +28,15 @@ class IssueInfo:
     gh_event_path: pydantic.FilePath
     submission: Submission = pydantic.Field(default=None)
 
-    def __post_init_post_parse__(self):
-        with open(self.gh_event_path) as f:
-            self.data = json.load(f)
-
     def create_submission(self):
         self._get_inputs()
         self._create_submission_input()
         return self
 
     def _get_inputs(self):
+        with open(self.gh_event_path) as f:
+            self.data = json.load(f)
+
         self.author = self.data['issue']['user']['login']
         self.title = self.data['issue']['title']
         self.body = self.data['issue']['body']

--- a/portal/index.md
+++ b/portal/index.md
@@ -149,9 +149,9 @@ the example data used by the [Pythia Foundations Book](https://foundations.proje
 
 ## Join us!
 
-If you have questions or want to share anything with the Project 
-Pythia Team, please reach out to us through the [Project Pythia 
-category on the Pangeo Discourse forum](https://discourse.pangeo.io/c/education/project-pythia/)  
+If you have questions or want to share anything with the Project
+Pythia Team, please reach out to us through the [Project Pythia
+category on the Pangeo Discourse forum](https://discourse.pangeo.io/c/education/project-pythia/)
 below or join us at our [Weekly Working Group Meetings](#weekly-working-group-meetings).
 
 <span class="d-flex justify-content-center pt-1 pb-4">


### PR DESCRIPTION
Closes #369.

Move `IssueInfo.data` initialization from `__post_init_post_parse__()` to `_… get_input_()` as `__post_init_post_parse__()` has been [removed from the API with Pydantic V2](https://docs.pydantic.dev/latest/migration/#changes-to-dataclasses).
