### PR TITLE
For PR #381: Run also from feature branch as well as main

### DIFF
--- a/.github/workflows/update-resource-gallery.yaml
+++ b/.github/workflows/update-resource-gallery.yaml
@@ -6,6 +6,7 @@ on:
       - opened
       - edited
     branches:
+      - main
       - fix-resource_gallery-workflow
 jobs:
   validate-user-submission:

--- a/.github/workflows/update-resource-gallery.yaml
+++ b/.github/workflows/update-resource-gallery.yaml
@@ -5,6 +5,8 @@ on:
     types:
       - opened
       - edited
+    branches:
+      - fix-resource_gallery-workflow
 jobs:
   validate-user-submission:
     if: |


### PR DESCRIPTION
Checking if the changes in PR #381 were successful is hard because the resource gallery submission action is running against the main branch. 

This PR is only for temporary purposes to get this action to run on the "fix-resource_gallery-workflow" branch that is the base of PR #381 instead of the main branch. Once we get that PR pass and merged, we can revert this PR's only change in the workflow file.

I couldn't think of an alternative solution in this case but am open to if there is any.
