### PR TITLE
Add Cookoff 2024 event link and blog post

### DIFF
--- a/portal/index.md
+++ b/portal/index.md
@@ -9,6 +9,11 @@
 
 <span style="font-size: 2.6rem;">An education and training hub for the geoscientific Python community</span>
 
+<a href="https://projectpythia.org/pythia-cookoff-2024/" role="button" class="btn btn-light btn-lg" style="display: flex; align-items: center; font-weight: 600; text-decoration: none; background-color: #ccc; border: rgba(var(--spt-color-dark), 1);">
+         Project Pythia is hosting a Cookbook Cook-Off June 10-14, 2024.<br>
+         Learn more here.
+ </a>
+
 [Project Pythia](about) is the education working group for [Pangeo](https://pangeo.io)
 and is an educational resource for the entire geoscience community.
 Together these initiatives are helping geoscientists make sense of huge volumes of

--- a/portal/posts/cookoff2024-website.md
+++ b/portal/posts/cookoff2024-website.md
@@ -1,0 +1,13 @@
+---
+blogpost: true
+date: Jan 8, 2024
+author: Brian Rose
+tags: cook-off
+---
+
+# Website is live for the 2024 Cook-off hackathon
+
+The 2024 Pythia Cookbook Cook-Off Hackathon will take place June
+10 - 14, at the NCAR Mesa Lab, located in Boulder, Colorado. 
+
+Check out [this preliminary website for the hackathon](https://projectpythia.org/pythia-cookoff-2024/)

--- a/portal/posts/cookoff2024-website.md
+++ b/portal/posts/cookoff2024-website.md
@@ -8,6 +8,6 @@ tags: cook-off
 # Website is live for the 2024 Cook-off hackathon
 
 The 2024 Pythia Cookbook Cook-Off Hackathon will take place June
-10 - 14, at the NCAR Mesa Lab, located in Boulder, Colorado. 
+10 - 14, at the NCAR Mesa Lab, located in Boulder, Colorado.
 
 Check out [this preliminary website for the hackathon](https://projectpythia.org/pythia-cookoff-2024/)


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Following the same button format we used last year, and adding a blog post. Both link to the new [Cook-off 2024 site](https://projectpythia.org/pythia-cookoff-2024/)