### PR TITLE
String manipulation on GH secret in metrics automation AND contributor's instructions

### DIFF
--- a/.github/workflows/get-metrics.py
+++ b/.github/workflows/get-metrics.py
@@ -20,7 +20,8 @@ COOKBOOKS_ID = '324070631'
 
 # Access Secrets
 PRIVATE_KEY_ID = os.environ.get('PRIVATE_KEY_ID')
-PRIVATE_KEY = os.environ.get('PRIVATE_KEY')
+# Ensure GH secrets doesn't intrudce extra '\' new line characters (related to '\' being an escape character)
+PRIVATE_KEY = os.environ.get('PRIVATE_KEY').replace('\\n', '\n')
 
 credentials_dict = {
     'type': 'service_account',
@@ -41,7 +42,9 @@ try:
 except google.auth.exceptions.MalformedError as e:
     print('Malformed Error:', repr(e))
     # Insight into reason for failure without exposing secret key
-    print('Length of PRIVATE_KEY:', len(PRIVATE_KEY))  # 0: Secret not found, ~734: Secret malformed
+    # 0: Secret not found, else malformed
+    # 706: extra quote, 732: extra '\', 734: both
+    print('Length of PRIVATE_KEY:', len(PRIVATE_KEY))
 
 pre_project_date = '2020-03-31'  # Random date before project start
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ Replace 'analytics-api-env' with any new environment name. Also, `pip install` a
 
 To interact with the Google Analytics API locally you need to download the credentials file. This file has been uploaded to the ProjectPythia Google Drive and lives in the Analytics_API folder.
 
-**This credentials file needs to be kept secure**, especially the `private_key` field. **Do NOT share this file.** If you do not have access to our Google Drive and need access to this file, please reach out to the team on discourse or in a community meeting. 
+**This credentials file needs to be kept secure**, especially the `private_key` field. **Do NOT share this file.** If you do not have access to our Google Drive and need access to this file, please reach out to the team on discourse or in a community meeting.
 
 The credentials file will have a name similar to `cisl-vast-pythia-{letters and numbers}.json`. This file may be replaced intermittently with a slightly differnt alphanumeric string for additional security.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ To interact with the Google Analytics API locally you need to download the crede
 
 **This credentials file needs to be kept secure**, especially the `private_key` field. **Do NOT share this file.** If you do not have access to our Google Drive and need access to this file, please reach out to the team on discourse or in a community meeting.
 
-The credentials file will have a name similar to `cisl-vast-pythia-{letters and numbers}.json`. This file may be replaced intermittently with a slightly differnt alphanumeric string for additional security.
+The credentials file will have a name similar to `cisl-vast-pythia-{letters and numbers}.json`. This file may be replaced intermittently with a slightly different alphanumeric string for additional security.
 
 One way to ensure that your Python script is using the correct credentials file is to read it as a dictionary and pass that into your API client at the begging of your script.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,11 +132,15 @@ source analytics-api-env/bin/activate
 pip install google-analytics-data
 ```
 
-Replacing 'analytics-api-env' with any new environment name. Also `pip install` any other packages you may want for your analytics work.
+Replace 'analytics-api-env' with any new environment name. Also, `pip install` any other packages you may want for your analytics work.
 
 ### Setting up Credentials
 
-To interact with the Google Analytics API locally you need to download the credentials file. This file has been uploaded to the ProjectPythia Google Drive and lives in the Analytics_API folder. It will have a name similar to `cisl-vast-pythia-{letters and numbers}.json`.
+To interact with the Google Analytics API locally you need to download the credentials file. This file has been uploaded to the ProjectPythia Google Drive and lives in the Analytics_API folder.
+
+**This credentials file needs to be kept secure**, especially the `private_key` field. **Do NOT share this file.** If you do not have access to our Google Drive and need access to this file, please reach out to the team on discourse or in a community meeting. 
+
+The credentials file will have a name similar to `cisl-vast-pythia-{letters and numbers}.json`. This file may be replaced intermittently with a slightly differnt alphanumeric string for additional security.
 
 One way to ensure that your Python script is using the correct credentials file is to read it as a dictionary and pass that into your API client at the begging of your script.
 
@@ -168,7 +172,9 @@ def _run_analytics_request(property_id):
     return response
 ```
 
-This function demonstrates how to format your `RunReportRequest()` arguments, notably the `dimensions` and `metrics` calls, as well as the expected date formatting in `date_ranges`. This [Google Analytics API Schema](https://developers.google.com/analytics/devguides/reporting/data/v1/api-schema) documentation lists all of the available dimension and metric keys that can be passed into your request.
+This function demonstrates how to format your `RunReportRequest()` arguments, notably the `dimensions` and `metrics` fields, as well as the expected date formatting in `date_ranges`.
+
+This [Google Analytics API Schema](https://developers.google.com/analytics/devguides/reporting/data/v1/api-schema) documentation lists all of the available dimension and metric keys that can be passed into your request.
 
 `property_id` is a 9-digit number associated with the project you are interested in. This number can be found on the Analytics project page. For Project Pythia, our three different property IDs are:
 ```


### PR DESCRIPTION
Related to #319 (won't close automatically, want to ensure the actions are all running smoothly after merge first).
Response to #413 

GH secrets treat new lines differently than the Google Analytics API key expects. Essentially '\\' is an escape character, so sometimes during the encryption and getting of the secret, GitHub escapes the new line and causes issues. For some reason GH secrets when returned can give '\\\n' where you'd expect '\n'.

Without printing the secret to ensure that this is the issue, I was able to confirm that the discrepancy in secret length aligns with extra '\\'s. This PR will find any '\\\n's and replace them with '\n'.

Maybe this was common knowledge, but I am amused that in this comment I have to add an extra '\\' everywhere for it to show up as intended in the preview.

Updates to the contributor's guide for accessing the analytics API is also included in this PR.