### PR TITLE
Point internal links to new guide

### DIFF
--- a/portal/contributing.md
+++ b/portal/contributing.md
@@ -3,8 +3,8 @@
 ```{Note}
 This the top-level guide for Project Pythia and a great starting point for getting involved!
 
-We also have specific guides for 
-[contributing to Pythia Foundations](https://foundations.projectpythia.org/appendix/how-to-contribute.html) 
+We also have specific guides for
+[contributing to Pythia Foundations](https://foundations.projectpythia.org/appendix/how-to-contribute.html)
 and [contributing new Cookbooks](https://projectpythia.org/cookbook-guide.html).
 ```
 
@@ -75,7 +75,7 @@ Ecosystem. The Pythia Foundations content is hosted on a separate
 and contributors should consult the contributor’s guide there for
 information specific to Foundations. However, adding new, or changing
 existing Foundations content requires contributors to be familiar
-with a few technologies and workflows, described in Advanced 
+with a few technologies and workflows, described in Advanced
 Contributions below.
 
 ### Add a new Cookbook to Cookbooks Gallery


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Added a clarifying note at the top of the main Contributors Guide, and updated links to the new location for the Cookbook guide.

More progress on #425 