### PR TITLE
Maxouptutlength

### DIFF
--- a/portal/conf.py
+++ b/portal/conf.py
@@ -140,6 +140,18 @@ linkcheck_ignore = [
     r'https://stackoverflow\.com/.*',
 ]
 
+# Optionally set the max output length directly if supported
+# If nbsphinx or myst_nb does not have this, refer to their documentation for correct usage
+nbsphinx_output_prompt = 300  # Example value
+
+# For MyST-NB, you can set notebook related configurations
+myst_nb_config = {
+    'output_prompt_height': 300,  # Example value, adjust as needed
+}
+
+# Ensure no invalid maxOutputLength setting
+maxOutputLength = 1024  # Setting a valid example value within the required range
+
 # CUSTOM SCRIPTS ==============================================================
 
 # Copy root files into content pages ------------------------------------------

--- a/portal/conf.py
+++ b/portal/conf.py
@@ -140,11 +140,10 @@ linkcheck_ignore = [
     r'https://stackoverflow\.com/.*',
 ]
 
-# Optionally set the max output length directly if supported
-# If nbsphinx or myst_nb does not have this, refer to their documentation for correct usage
+# Set the max output length directly if supported
 nbsphinx_output_prompt = 300  # Example value
 
-# For MyST-NB, you can set notebook related configurations
+# For MyST-NB, set notebook related configurations
 myst_nb_config = {
     'output_prompt_height': 300,  # Example value, adjust as needed
 }


### PR DESCRIPTION
Attempt to fix book build failure

The build failed with 
```
The value of "options.maxOutputLength" is out of range. It must be >= 1 and <= 4294967296. Received 0
```

even though it builds locally and in the preview. Not sure how to test if this will fix that without merging. Anyone have any insight into what is happening here?

Also confusing that it passes the build step in `pages-build-deploy` but fails build in `publish`.