### PR TITLE
Fix publish-site.yaml 

### DIFF
--- a/.github/workflows/publish-site.yaml
+++ b/.github/workflows/publish-site.yaml
@@ -30,6 +30,7 @@ jobs:
         with:
           name: repo-zip
           path: .
+          include-hidden-files: 'true'
 
   build:
     needs: automate-metrics
@@ -39,6 +40,10 @@ jobs:
       environment_name: pythia
       path_to_notebooks: 'portal'
       build_command: 'make -j4 html'
+      build_from_code_artifact: 'true'
+      code_artifact_name: 'repo-zip'
+      workflow: ''
+      workflow_conclusion: ''
   deploy:
     needs: build
     uses: ProjectPythia/cookbook-actions/.github/workflows/deploy-book.yaml@main

--- a/.github/workflows/publish-site.yaml
+++ b/.github/workflows/publish-site.yaml
@@ -39,10 +39,6 @@ jobs:
       environment_name: pythia
       path_to_notebooks: 'portal'
       build_command: 'make -j4 html'
-      build_from_code_artifact: 'true'
-      code_artifact_name: 'repo-zip'
-      workflow: ''
-      workflow_conclusion: ''
   deploy:
     needs: build
     uses: ProjectPythia/cookbook-actions/.github/workflows/deploy-book.yaml@main


### PR DESCRIPTION
In an attempt to fix the Issue #457, remove `build_from_code_artifact: 'true'` from `build` job of the publish-site.yaml. 

EDIT 2024-9-17: Never mind the above description; we revert those changes. Instead, add `include-hidden-files` into upload-artifact re this [release note](https://github.com/actions/upload-artifact/releases/tag/v4.4.0) per @brian-rose 's [comment](https://github.com/ProjectPythia/projectpythia.github.io/issues/457#issuecomment-2356706620).