### PR TITLE
Switch link checker workflow to miniforge

### DIFF
--- a/.github/workflows/sphinx-link-checker.yaml
+++ b/.github/workflows/sphinx-link-checker.yaml
@@ -33,14 +33,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Mambaforge
+      - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v2
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           python-version: "3.10"  # binderbot is failing with python 3.11
           activate-environment: ${{ inputs.environment_name }}
-          use-mamba: true
 
       - name: Set cache date
         if: inputs.use_cached_environment == 'true'
@@ -60,8 +58,8 @@ jobs:
           (inputs.use_cached_environment != 'true'
           || steps.cache.outputs.cache-hit != 'true')
         run: |
-          mamba env update -n ${{ inputs.environment_name }} -f ${{ inputs.environment_file }}
-          mamba install -c conda-forge sphinxcontrib-applehelp=1.0.4 sphinxcontrib-devhelp=1.0.2 sphinxcontrib-htmlhelp=2.0.1 sphinxcontrib-qthelp=1.0.3 sphinxcontrib-serializinghtml=1.1.5
+          conda env update -n ${{ inputs.environment_name }} -f ${{ inputs.environment_file }}
+          conda install -c conda-forge sphinxcontrib-applehelp=1.0.4 sphinxcontrib-devhelp=1.0.2 sphinxcontrib-htmlhelp=2.0.1 sphinxcontrib-qthelp=1.0.3 sphinxcontrib-serializinghtml=1.1.5
 
       - name: Check external links
         run: |


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Related to https://github.com/ProjectPythia/cookbook-actions/pull/124. This PR replaces Mambaforge with Miniforge in the custom link-checker workflow housed in this repo.