### PR TITLE
Remove cname input to deploy-book workflow

### DIFF
--- a/.github/workflows/publish-site.yaml
+++ b/.github/workflows/publish-site.yaml
@@ -48,5 +48,4 @@ jobs:
     needs: build
     uses: ProjectPythia/cookbook-actions/.github/workflows/deploy-book.yaml@main
     with:
-      cname: projectpythia.org
       publish_dir: 'portal/_build/html'

--- a/.github/workflows/trigger-preview.yaml
+++ b/.github/workflows/trigger-preview.yaml
@@ -19,7 +19,6 @@ jobs:
       artifact_name: book-zip-${{ needs.find-pull-request.outputs.number }}
       destination_dir: _preview/${{ needs.find-pull-request.outputs.number }}  # deploy to subdirectory labeled with PR number
       is_preview: 'true'
-      cname: projectpythia.org
       publish_dir: 'portal/_build/html'
 
   preview-comment:


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Same as https://github.com/ProjectPythia/pythia-foundations/pull/496

This needs doing for consistency with https://github.com/ProjectPythia/cookbook-actions/pull/135

The preview will fail here, that is expected.