### PR TITLE
Update CODEOFCONDUCT.md to provide a clear way of reporting instances to the Pythia community leaders

### DIFF
--- a/CODEOFCONDUCT.md
+++ b/CODEOFCONDUCT.md
@@ -43,7 +43,7 @@ Project administrators are responsible for clarifying the standards of acceptabl
 
 ## Reporting
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the the @ProjectPythia/core GitHub handle and/or projectpythia@ucar.edu as the community leaders in charge of these can view and manage the reported content, and hence are responsible for enforcement as outlined in the Consequences section below.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the @ProjectPythia/core GitHub handle and/or projectpythia@ucar.edu as the community leaders in charge of these can view and manage the reported content, and hence are responsible for enforcement as outlined in the Consequences section below.
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CODEOFCONDUCT.md
+++ b/CODEOFCONDUCT.md
@@ -43,7 +43,11 @@ Project administrators are responsible for clarifying the standards of acceptabl
 
 ## Reporting
 
-Instances of unacceptable behavior can be brought to the attention of the project administrator(s) who may take any action as outlined in the Consequences section below.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the the @ProjectPythia/core GitHub handle and/or projectpythia@ucar.edu as the community leaders in charge of these can view and manage the reported content, and hence are responsible for enforcement as outlined in the Consequences section below.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
 ## Consequences
 


### PR DESCRIPTION
Created in order to provide the community with a clear email etc. to report any unacceptable instances in the Code of Conduct. We are now adding the ProjectPythia/core Github team and the Pythia's email alias into the CoC to address this.

The updated text is adapted from the [Contributor Covenant Code of Conduct, version 2.1](https://www.contributor-covenant.org/), [version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html)

<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
