### PR TITLE
Remove maintenance banner; fix cookbook banner

### DIFF
--- a/portal/index.md
+++ b/portal/index.md
@@ -11,10 +11,6 @@
 
 <br><br>
 
-<a href="posts/binderhub_status.html" role="button" class="btn btn-light btn-lg" style="display: flex; align-items: center; font-weight: 600; text-decoration: none; background-color: orange; border: rgba(var(--spt-color-dark), 1);">
-         Pythia BinderHub Maintenance Monday Jan. 20, 2025
- </a>
-<br
 <a href="posts/new-cookbooks.html" role="button" class="btn btn-light btn-lg" style="display: flex; align-items: center; font-weight: 600; text-decoration: none; ">
           Round-up of new Cookbooks from our 2024 Cook-off hackathon!
   </a>


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
The latest binder hub maintenance banner inadvertently broke the banner about new Cookbooks.

I think we are done with BinderHub maintenance so I'm removing that banner and fixing the other one.

In general I suggest we leave the blog posts themselves intact, so I'm not touching that part.