### PR TITLE
feat: use upstream config for contributors

### DIFF
--- a/portal/posts/binderhub_status.md
+++ b/portal/posts/binderhub_status.md
@@ -1,7 +1,7 @@
 ---
 date: 2025-01-20
-author: Kevin Tyle
-tags: ['binderhub', 'maintenance']
+author: ktyle
+tags: ["binderhub", "maintenance"]
 ---
 
 # binder.projectpythia.org Maintenance

--- a/portal/posts/cookoff2023.md
+++ b/portal/posts/cookoff2023.md
@@ -1,6 +1,6 @@
 ---
 date: 2023-06-28
-author: Julia kent
+author: jukent
 tags: [cook-off]
 ---
 

--- a/portal/posts/cookoff2024-savethedate.md
+++ b/portal/posts/cookoff2024-savethedate.md
@@ -1,6 +1,6 @@
 ---
 date: 2023-08-29
-author: John Clyne
+author: clyne
 tags: [cook-off]
 ---
 

--- a/portal/posts/cookoff2024-website.md
+++ b/portal/posts/cookoff2024-website.md
@@ -1,6 +1,6 @@
 ---
 date: 2024-01-08
-author: Brian Rose
+author: brian-rose
 tags: [cook-off]
 ---
 

--- a/portal/posts/cookoff2025-website.md
+++ b/portal/posts/cookoff2025-website.md
@@ -1,6 +1,6 @@
 ---
 date: 2025-02-20
-author: Julia Kent
+author: jukent
 tags: [cook-off]
 ---
 

--- a/portal/posts/fundraiser.md
+++ b/portal/posts/fundraiser.md
@@ -1,6 +1,6 @@
 ---
 date: 2023-06-28
-author: Julia kent
+author: jukent
 tags: [fundraiser]
 ---
 

--- a/portal/posts/new-cookbooks.md
+++ b/portal/posts/new-cookbooks.md
@@ -1,6 +1,6 @@
 ---
 date: 2025-01-10
-author: Brian Rose
+author: brian-rose
 tags: [cook-off]
 ---
 


### PR DESCRIPTION
> [!Important]
> Depends upon https://github.com/ProjectPythia/pythia-config/pull/12

This PR uses GitHub IDs for blog post authors, which are mapped to contributor details in the upstream `pythia.yml`.