### PR TITLE
Fix syntax in link-checker workflow call

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -26,4 +26,4 @@ jobs:
     if: ${{ github.repository_owner == 'ProjectPythia' }}
     uses: ProjectPythia/cookbook-actions/.github/workflows/link-checker.yaml@main
     with:
-      path_to_source: 'portal'
+      path_to_notebooks: 'portal'

--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,4 @@ dependencies:
 - pre-commit
 - pyyaml
 - mystmd
+- jupyterlab


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Will get the nightly-build running again.