### PR TITLE
Explicit ordering of blog posts

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,4 @@ dependencies:
 - pre-commit
 - pyyaml
 - mystmd
+- jupyterlab

--- a/portal/myst.yml
+++ b/portal/myst.yml
@@ -12,7 +12,15 @@ project:
     - file: about.md
     - title: Blog
       children:
-        - pattern: posts/*.md
+        # - pattern: posts/*.md
+        #  Temporary until we have blog infrastructure: explicit list of posts by date (newest first)
+        - posts/cookoff2025-website.md
+        - posts/binderhub_status.md
+        - posts/new-cookbooks.md
+        - posts/cookoff2024-website.md
+        - posts/cookoff2024-savethedate.md
+        - posts/fundraiser.md
+        - posts/cookoff2023.md
     - file: contributing.md
     - file: cookbook-guide.md
     - file: metrics.md


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This PR is a temporary fix for #516. 

Until we have a proper blogging solution in place, we can just manually list each post in the `myst.yml` in the order we want them to appear.