### PR TITLE
Temporary fix: define the footer locally

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,4 @@ dependencies:
 - pre-commit
 - pyyaml
 - mystmd
+- jupyterlab

--- a/portal/myst.yml
+++ b/portal/myst.yml
@@ -20,3 +20,34 @@ site:
   domains: []
   options:
     style: style.css
+
+# Temporary until the upstream footer definition is working
+parts:
+    footer: |
+        :::::{grid} 3
+        :class: items-center
+
+
+        ```{image} https://raw.githubusercontent.com/ProjectPythia/pythia-config/main/logos/NSF-NCAR.png
+        :alt: NCAR Logo
+        ```
+
+        ```{image} https://raw.githubusercontent.com/ProjectPythia/pythia-config/main/logos/NSF-Unidata.png
+        :alt: Unidata Logo
+        ```
+
+        ```{image} https://raw.githubusercontent.com/ProjectPythia/pythia-config/main/logos/UAlbany.svg
+        :alt: UAlbany Logo
+        ```
+        :::::
+
+        :::::{div}
+        :class: flex items-center gap-4 text-disclaimer
+
+        ```{image} https://raw.githubusercontent.com/ProjectPythia/pythia-config/main/logos/nsf.jpg
+        :alt: NSF Logo
+        :height: 60px
+        ```
+
+        This material is based upon work supported by the National Science Foundation under Grant Nos. 2026863 and 2026899. Any opinions, findings, and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation.
+        :::::


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Temporary workaround until #530 is resolved.

This PR just defines the footer locally for the portal site, so it will at least display there.