### PR TITLE
Restrict blog post list path

### DIFF
--- a/portal/src/blogpost.py
+++ b/portal/src/blogpost.py
@@ -14,9 +14,9 @@ DEFAULTS = {"number": 10}
 
 root = Path(__file__).parent.parent
 
-# Aggregate all posts from the markdown and ipynb files
+# Aggregate all posts from the markdown files
 posts = []
-for ifile in root.rglob("posts/**/*.md"):
+for ifile in root.rglob("posts/????/*.md"):
     if "drafts" in str(ifile):
         continue
 


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This PR puts in a more stringent glob path to look for blog posts. I encountered issues when building the site locally with stray extra posts showing up on the rendered page that were found in the `_build` directory.