### PR TITLE
Bring CODE-OF-CONDUCT from being under review to publication again

### DIFF
--- a/CODEOFCONDUCT.md
+++ b/CODEOFCONDUCT.md
@@ -15,7 +15,7 @@ Examples of behaviors that contribute to a positive environment include:
 - Avoiding personal attacks directed toward other contributors
 - Being mindful of your surroundings and of your fellow contributors
 - Alerting UCAR staff and suppliers/vendors if you notice a dangerous situation or someone in distress
-- Respect the rules and policies of the project and venue
+- Respecting the rules and policies of the project and venue
 
 Examples of unacceptable behavior include, but are not limited to:
 


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->

Our CoC has long been under review, and now that we have UCAR's guidance for the newer CoCs for a while now, I believe we can get it published back with the updates. 

If you are curious about the differences between this and its latest published version , check [this version of it](https://github.com/ProjectPythia/projectpythia.github.io/blob/5ca1254579d1ef2d35a7bfbf1a9e05025d9fc2d9/CODEOFCONDUCT.md) out.
