### PR TITLE
Remove locally defined footer

### DIFF
--- a/portal/myst.yml
+++ b/portal/myst.yml
@@ -40,4 +40,3 @@ site:
   options:
     style: style.css
     analytics_google: G-T9KGMX7VHZ # Measurement ID or Tracking ID
-  

--- a/portal/myst.yml
+++ b/portal/myst.yml
@@ -40,32 +40,4 @@ site:
   options:
     style: style.css
     analytics_google: G-T9KGMX7VHZ # Measurement ID or Tracking ID
-  parts:
-    footer: |
-        :::::{grid} 3
-        :class: items-center
-
-
-        ```{image} https://raw.githubusercontent.com/ProjectPythia/pythia-config/main/logos/NSF-NCAR.png
-        :alt: NCAR Logo
-        ```
-
-        ```{image} https://raw.githubusercontent.com/ProjectPythia/pythia-config/main/logos/NSF-Unidata.png
-        :alt: Unidata Logo
-        ```
-
-        ```{image} https://raw.githubusercontent.com/ProjectPythia/pythia-config/main/logos/UAlbany.svg
-        :alt: UAlbany Logo
-        ```
-        :::::
-
-        :::::{div}
-        :class: flex items-center gap-4 text-disclaimer
-
-        ```{image} https://raw.githubusercontent.com/ProjectPythia/pythia-config/main/logos/nsf.jpg
-        :alt: NSF Logo
-        :height: 60px
-        ```
-
-        This material is based upon work supported by the National Science Foundation under Grant Nos. 2026863 and 2026899. Any opinions, findings, and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation.
-        :::::
+  


### PR DESCRIPTION
Removed footer parts including logos and disclaimer text.

<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Now that the upstream footer is displaying across all pages, as intended, we can reverse #531 and get rid of the local definition.